### PR TITLE
Removed 1 unnecessary stubbings in ThreadPoolMetricsGaugesTest.java

### DIFF
--- a/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolMetricsGaugesTest.java
+++ b/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolMetricsGaugesTest.java
@@ -88,7 +88,6 @@ public class ThreadPoolMetricsGaugesTest {
         when(bean.getMBeanInfo()).thenReturn(info);
         when(bean.getAttribute(eq(ATTR_A_NAME))).thenReturn(new Attributes().getA());
         when(bean.getAttribute(eq(ATTR_B_NAME))).thenReturn(new Attributes().getB());
-        when(bean.getAttribute(eq(ATTR_C_NAME))).thenReturn(new Attributes().getC());
         when(bean.getAttribute(eq(ATTR_D_NAME)))
                 .thenThrow(new JMRuntimeException("this exception is for unit test only"));
 


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 unnecessary stubbing in `ThreadPoolMetricsGaugesTest.testGaugesCreation` is created but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.